### PR TITLE
chore: upgrade all NuGet packages to latest versions

### DIFF
--- a/MudBlazor.PhosphorIcons/MudBlazor.PhosphorIcons.csproj
+++ b/MudBlazor.PhosphorIcons/MudBlazor.PhosphorIcons.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.8"/>
-    <PackageReference Include="MudBlazor" Version="7.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.19"/>
+    <PackageReference Include="MudBlazor" Version="8.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Phosphor.UnitTests/Phosphor.UnitTests.csproj
+++ b/Phosphor.UnitTests/Phosphor.UnitTests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-    <PackageReference Include="NUnit" Version="3.14.0"/>
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+    <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Phosphor/Phosphor.csproj
+++ b/Phosphor/Phosphor.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="7.8.0" />
+    <PackageReference Include="MudBlazor" Version="8.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.1.0" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated packages:
- MudBlazor: 7.8.0 → 8.13.0
- Microsoft.AspNetCore.Components.Web: 8.0.8 → 8.0.19
- Nuke.Common: 8.1.0 → 9.0.4
- Microsoft.NET.Test.Sdk: 17.8.0 → 18.0.0
- NUnit: 3.14.0 → 4.4.0
- NUnit.Analyzers: 3.9.0 → 4.11.0
- NUnit3TestAdapter: 4.5.0 → 5.2.0
- coverlet.collector: 6.0.0 → 6.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)